### PR TITLE
expose ChangeMessageVisibility

### DIFF
--- a/sqs/queue.go
+++ b/sqs/queue.go
@@ -246,6 +246,19 @@ func (q *Queue) AddDeleteList(msg interface{}) {
 	}
 }
 
+// ChangeMessageVisibility sends the request to AWS api to change visibility of the message.
+func (q *Queue) ChangeMessageVisibility(msg *Message, timeoutInSeconds int) error {
+	_, err := q.service.client.ChangeMessageVisibility(&SDK.ChangeMessageVisibilityInput{
+		QueueUrl:          q.url,
+		VisibilityTimeout: pointers.Long(timeoutInSeconds),
+		ReceiptHandle:     msg.GetReceiptHandle(),
+	})
+	if err != nil {
+		q.service.Errorf("error on `ChangeMessageVisibility`; queue=%s; error=%s;", q.nameWithPrefix, err.Error())
+	}
+	return err
+}
+
 // DeleteMessage sends the request to AWS api to delete the message.
 func (q *Queue) DeleteMessage(msg *Message) error {
 	_, err := q.service.client.DeleteMessage(&SDK.DeleteMessageInput{

--- a/sqs/queue_test.go
+++ b/sqs/queue_test.go
@@ -207,6 +207,24 @@ func TestAddDeleteList(t *testing.T) {
 
 }
 
+func TestChangeMessageVisibility(t *testing.T) {
+	assert := assert.New(t)
+	svc := getTestClient(t)
+	q, _ := svc.GetQueue("test")
+	cleanQueue(q)
+
+	// prepare messages
+	addTestMessage(q, 3)
+	msg, err := q.FetchOne()
+	assert.Nil(err)
+
+	// test this feature
+	err = q.ChangeMessageVisibility(msg, 1)
+	assert.Nil(err)
+
+	cleanQueue(q)
+}
+
 func TestDeleteMessage(t *testing.T) {
 	assert := assert.New(t)
 	svc := getTestClient(t)


### PR DESCRIPTION
ChangeMessageVisibility is an important feature to executing some task that needs takes a long time to run(e.g. video encoding).