### PR TITLE
[SNS] Add APNs key

### DIFF
--- a/sns/helper.go
+++ b/sns/helper.go
@@ -9,6 +9,7 @@ const (
 	apnsKeySound          = "sound"
 	apnsKeyCategory       = "category"
 	apnsKeyBadge          = "badge"
+	apnsKeyMutableContent = "mutable-content"
 )
 
 const fcmPriorityHigh = "high"
@@ -49,6 +50,10 @@ func composeMessageAPNS(msg string, opt map[string]interface{}) (payload string,
 		aps[apnsKeyBadge] = v
 	}
 
+	if v, ok := opt[apnsKeyMutableContent]; ok {
+		aps[apnsKeyMutableContent] = v
+	}
+
 	message := make(map[string]interface{})
 	message["aps"] = aps
 	for k, v := range opt {
@@ -58,6 +63,8 @@ func composeMessageAPNS(msg string, opt map[string]interface{}) (payload string,
 		case apnsKeyCategory:
 			continue
 		case apnsKeyBadge:
+			continue
+		case apnsKeyMutableContent:
 			continue
 		default:
 			message[k] = v

--- a/sns/helper_test.go
+++ b/sns/helper_test.go
@@ -56,15 +56,22 @@ func TestComposeMessageAPNS(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(`{"aps":{"alert":"test","badge":5,"sound":"default"}}`, msg)
 
+	delete(opt, "badge")
+	opt["mutable-content"] = 1
+	msg, err = composeMessageAPNS("test", opt)
+	assert.NoError(err)
+	assert.Equal(`{"aps":{"alert":"test","mutable-content":1,"sound":"default"}}`, msg)
+
 	opt["sound"] = "jazz"
 	opt["category"] = "new_message"
 	opt["badge"] = 5
+	opt["mutable-content"] = 1
 	msg, err = composeMessageAPNS("test", opt)
 	assert.NoError(err)
-	assert.Equal(`{"aps":{"alert":"test","badge":5,"category":"new_message","sound":"jazz"}}`, msg)
+	assert.Equal(`{"aps":{"alert":"test","badge":5,"category":"new_message","mutable-content":1,"sound":"jazz"}}`, msg)
 
 	opt["x-option"] = "foo"
 	msg, err = composeMessageAPNS("test", opt)
 	assert.NoError(err)
-	assert.Equal(`{"aps":{"alert":"test","badge":5,"category":"new_message","sound":"jazz"},"x-option":"foo"}`, msg)
+	assert.Equal(`{"aps":{"alert":"test","badge":5,"category":"new_message","mutable-content":1,"sound":"jazz"},"x-option":"foo"}`, msg)
 }


### PR DESCRIPTION
Added a new APNs key 'mutable-content' for sending notification with images to iOS.

Documentation of 'mutable-content': 
[Modifying Content in Newly Delivered Notifications | Apple Developer Documentation](https://developer.apple.com/documentation/usernotifications/modifying_content_in_newly_delivered_notifications)