### PR TITLE
[DynamoDB] feat: Add 'ConditionList.AddKeyAttribute' method

### DIFF
--- a/dynamodb/condition.go
+++ b/dynamodb/condition.go
@@ -241,6 +241,11 @@ func (c *ConditionList) getMergedConditions() map[string]*Condition {
 	return list
 }
 
+// AddKeyAttribute adds to attribute to keyAttributes.
+func (c *ConditionList) AddKeyAttribute(attr AttributeDefinition) {
+	c.keyAttributes[attr.Name] = attr.Type
+}
+
 // Condition contains condition.
 type Condition struct {
 	Condition string


### PR DESCRIPTION
This PR adds `AddKeyAttribute` method on `ConditionList{}`.
This method allows you to use a query filter on non-index columns.

(index columns can be get the definitions through `DescribeTable` API  and are added to `keyAttribute`  by default)


## Example usage

```go
// var table *dynamodb.Table
// table = NewTable(svc, tableName)
now := time.Now()

cond := table.NewConditionList()

// my-index: primary-key=user_id, secondary-key=created_at
cond.SetIndex("my-index") 
cond.AndEQ("user_id", 101)
cond.AndBETWEEN("created_at", now.AddDate(0, 0, -1).Unix(), now.Unix())
cond.SetLimit(1)
cond.SetDesc(true)

cond.FilterEQ("language", "en") // `language` is non-index column
cond.AddKeyAttribute(dynamodb.NewStringAttribute("language"))

result, err := table.Query(cond)

// ---------------
// pseudo-sql
// ---------------
// SELECT * FROM tableName
// WHERE user_id = 101
//   AND created_at BETWEEN <yesterday> AND <now>
//   AND language = 'en'
// ORDER BY created_at DESC
// LIMIT 1
```

