### PR TITLE
Add single msg sending

### DIFF
--- a/sqs/queue.go
+++ b/sqs/queue.go
@@ -166,6 +166,18 @@ func (q *Queue) send(msg []*SDK.SendMessageBatchRequestEntry) error {
 	return err
 }
 
+// SendSingleMessage sends a message directly to the SQS immediately
+// and bypasses the spool and batch submits.
+func (q *Queue) SendSingleMessage(message string) (string, error) {
+
+	res, err := q.service.client.SendMessage(&SDK.SendMessageInput{
+		MessageBody: pointers.String(message),
+		QueueUrl:    q.url,
+	})
+
+	return res.GoString(), err
+}
+
 // Fetch fetches message list from the queue with limit.
 func (q *Queue) Fetch(num int) ([]*Message, error) {
 	wait := q.waitTimeSeconds

--- a/sqs/queue.go
+++ b/sqs/queue.go
@@ -169,12 +169,10 @@ func (q *Queue) send(msg []*SDK.SendMessageBatchRequestEntry) error {
 // SendSingleMessage sends a message directly to the SQS immediately
 // and bypasses the spool and batch submits.
 func (q *Queue) SendSingleMessage(message string) (string, error) {
-
 	res, err := q.service.client.SendMessage(&SDK.SendMessageInput{
 		MessageBody: pointers.String(message),
 		QueueUrl:    q.url,
 	})
-
 	return res.GoString(), err
 }
 

--- a/sqs/queue_test.go
+++ b/sqs/queue_test.go
@@ -107,6 +107,16 @@ func TestSend(t *testing.T) {
 	assert.Nil(err)
 }
 
+func TestSendSingleMessage(t *testing.T) {
+	assert := assert.New(t)
+	svc := getTestClient(t)
+	q, _ := svc.GetQueue("test")
+
+	result, err := q.SendSingleMessage("foo sending single message")
+	assert.NotNil(result)
+	assert.Nil(err)
+}
+
 func TestFetch(t *testing.T) {
 	assert := assert.New(t)
 	svc := getTestClient(t)


### PR DESCRIPTION
This adds a method allowing the sending of a message directly to the SQS Q and bypass the spool and batch processing. 